### PR TITLE
Fix reference to cursor element

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ AFRAME.registerComponent('controller-cursor', {
    * Remove event listeners.
    */
   pause: function () {
+    var cursorEl = this.el;
     cursorEl.removeEventListener('raycaster-intersection', this.onIntersectionBind);
     cursorEl.removeEventListener('raycaster-intersection-cleared',
                                  this.onIntersectionClearedBind);


### PR DESCRIPTION
Reference to cursorEl is not correctly initialised before attempting to remove event listeners.